### PR TITLE
Add SSH CLI capability

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,10 +10,10 @@ end
 
 namespace(:test) do
   desc 'Run all integration tests'
-  task integration: %i(integration:cli_local)
+  task integration: %i(integration:cli_ssh)
 
   Rake::TestTask.new(:unit) do |t|
-    t.libs.push 'lib'
+    t.libs.concat %w{test lib}
     t.test_files = FileList[
       'test/unit/*_test.rb',
     ]
@@ -42,7 +42,7 @@ namespace(:test) do
     task cli_ssh: [:sup_start, :cli_ssh_actual, :sup_shutdown]
     Rake::TestTask.new(:cli_ssh_actual) do |t|
       t.description = nil
-      t.libs.push 'lib'
+      t.libs.concat %w{test lib}
       t.test_files = FileList[
         'test/integration/ssh/*_test.rb',
       ]

--- a/Rakefile
+++ b/Rakefile
@@ -38,11 +38,17 @@ namespace(:test) do
       end
     end
 
-    # desc 'Use some cli transport to talk to supervisor'
-    # task :cli_thing => [:sup_start, :cli_thing_actual, :sup_shutdown]
-    # task :cli_thing_actual do
-    #   # Your code goes here
-    # end
+    desc 'Use ssh cli transport to talk to supervisor'
+    task cli_ssh: [:sup_start, :cli_ssh_actual, :sup_shutdown]
+    Rake::TestTask.new(:cli_ssh_actual) do |t|
+      t.description = nil
+      t.libs.push 'lib'
+      t.test_files = FileList[
+        'test/integration/ssh/*_test.rb',
+      ]
+      t.verbose = true
+      t.warning = false
+    end
   end
 end
 

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -72,6 +72,7 @@ module TrainPlugins
           unless prefix
             raise Train::TransportError, "All Habitat CLI connection options must begin with a recognized prefix (#{valid_cli_prefixes.join(', ')}) - saw #{option}"
           end
+
           options_by_prefix[prefix] ||= []
           options_by_prefix[prefix] << option
         end

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -72,7 +72,6 @@ module TrainPlugins
           unless prefix
             raise Train::TransportError, "All Habitat CLI connection options must begin with a recognized prefix (#{valid_cli_prefixes.join(', ')}) - saw #{option}"
           end
-
           options_by_prefix[prefix] ||= []
           options_by_prefix[prefix] << option
         end

--- a/lib/train-habitat/transport.rb
+++ b/lib/train-habitat/transport.rb
@@ -19,7 +19,7 @@ module TrainPlugins
       def self.cli_transport_prefixes
         {
           # add transports here, prefix => transport name
-          # cli_ssh: :ssh,
+          cli_ssh: :ssh,
         }
       end
 

--- a/test/integration/ssh/run_command_test.rb
+++ b/test/integration/ssh/run_command_test.rb
@@ -1,0 +1,28 @@
+require 'helper'
+require 'logger'
+require 'train-habitat'
+
+describe 'Using the SSH CLI transport' do
+  let(:transport_opts) do
+    {
+      # These are determined by the Vagrantfile
+      cli_ssh_host: '127.0.0.1',
+      cli_ssh_user: 'vagrant',
+      cli_ssh_port: '9022',
+      cli_ssh_key_files: ['test/integration/shared/.vagrant/machines/default/virtualbox/private_key'],
+
+      # TODO: this gets ignored
+      logger: Logger.new(STDOUT, level: :info),
+      sudo: true,
+    }
+  end
+  let(:hab_conn) { Train.create(:habitat, transport_opts).connection }
+
+  describe 'when using defaults' do
+    it 'should be able to get the hab version' do
+      result = hab_conn.run_hab_cli('--version')
+      result.exit_status.must_equal 0
+      result.stdout.must_match /^hab\s+\d+\.\d+\.\d+\/\d+\n/
+    end
+  end
+end

--- a/test/integration/ssh/run_command_test.rb
+++ b/test/integration/ssh/run_command_test.rb
@@ -22,7 +22,7 @@ describe 'Using the SSH CLI transport' do
       result = hab_conn.run_hab_cli('--version')
       result.exit_status.must_equal 0
       # "hab 0.77.0/20190301212334\n"
-      result.stdout.must_match /^hab\s+\d+\.\d+\.\d+\/\d+\n/
+      result.stdout.must_match %r{^hab\s+\d+\.\d+\.\d+/\d+\n}
     end
   end
 
@@ -33,7 +33,7 @@ describe 'Using the SSH CLI transport' do
       result.exit_status.must_equal 0
       # package                           type        desired  state  elapsed (s)  pid   group\n
       # core/httpd/2.4.35/20190307151146  standalone  up       up     28521        1407  httpd.default\n
-      result.stdout.must_match /^package\s+type\s+/
+      result.stdout.must_match(/^package\s+type\s+/)
     end
   end
 end

--- a/test/integration/ssh/run_command_test.rb
+++ b/test/integration/ssh/run_command_test.rb
@@ -11,9 +11,8 @@ describe 'Using the SSH CLI transport' do
       cli_ssh_port: '9022',
       cli_ssh_key_files: ['test/integration/shared/.vagrant/machines/default/virtualbox/private_key'],
 
-      # TODO: this gets ignored
-      logger: Logger.new(STDOUT, level: :info),
-      sudo: true,
+      logger: Logger.new(STDOUT, level: :warn), # TODO: This is consumed by train/base_connection, but appears to be ignored
+      sudo: true, # This is needed on the Vagrantbox setup
     }
   end
   let(:hab_conn) { Train.create(:habitat, transport_opts).connection }
@@ -22,7 +21,19 @@ describe 'Using the SSH CLI transport' do
     it 'should be able to get the hab version' do
       result = hab_conn.run_hab_cli('--version')
       result.exit_status.must_equal 0
+      # "hab 0.77.0/20190301212334\n"
       result.stdout.must_match /^hab\s+\d+\.\d+\.\d+\/\d+\n/
+    end
+  end
+
+  describe 'when using a setup that requires sudo' do
+    it 'should be able to get the hab version' do
+      result = hab_conn.run_hab_cli('svc status')
+      result.stderr.must_equal ''
+      result.exit_status.must_equal 0
+      # package                           type        desired  state  elapsed (s)  pid   group\n
+      # core/httpd/2.4.35/20190307151146  standalone  up       up     28521        1407  httpd.default\n
+      result.stdout.must_match /^package\s+type\s+/
     end
   end
 end

--- a/test/unit/cli_ssh_test.rb
+++ b/test/unit/cli_ssh_test.rb
@@ -1,0 +1,27 @@
+# Tests the ability of the transport to use SSH as a CLI subtransport
+require 'helper'
+require 'train-habitat/connection'
+require 'train'
+require 'train/transports/ssh'
+
+
+describe TrainPlugins::Habitat::Connection do
+  subject { TrainPlugins::Habitat::Connection }
+  let(:conn) { subject.new(opt) }
+
+  describe 'recognizing basic SSH options with prefixes' do
+    let(:opt) do
+      {
+        cli_ssh_host: 'localhost',
+        cli_ssh_port: 8022,
+        cli_ssh_user: 'hab_user',
+      }
+    end
+    it 'should be able to make a SSH Transport object' do
+      Train::Transports::SSH.any_instance.stubs(:connection)
+      conn.cli_transport_name.must_equal :ssh
+      conn.cli_transport.wont_be_nil
+      conn.cli_transport.must_be_kind_of(Train::Transports::SSH)
+    end
+  end
+end

--- a/test/unit/cli_ssh_test.rb
+++ b/test/unit/cli_ssh_test.rb
@@ -4,7 +4,6 @@ require 'train-habitat/connection'
 require 'train'
 require 'train/transports/ssh'
 
-
 describe TrainPlugins::Habitat::Connection do
   subject { TrainPlugins::Habitat::Connection }
   let(:conn) { subject.new(opt) }

--- a/test/unit/platform_test.rb
+++ b/test/unit/platform_test.rb
@@ -2,6 +2,7 @@
 
 require './test/helper'
 require './lib/train-habitat/platform'
+require './lib/train-habitat/connection'
 
 describe TrainPlugins::Habitat::Platform do
   subject { TrainPlugins::Habitat::Platform }


### PR DESCRIPTION
This enables the train SSH transport to be used as a way of connecting to a machine that has hab and sup running on the same machine. That allows the `hab` cli to be used to query things that the HTTP gateway cannot report on, such as packages.