### PR TITLE
Update API implementation and tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 
 namespace(:test) do
   desc 'Run all integration tests'
-  task integration: %i(integration:cli_ssh)
+  task integration: %i(integration:sup_start integration:api_actual integration:cli_ssh_actual integration:sup_shutdown)
 
   Rake::TestTask.new(:unit) do |t|
     t.libs.concat %w{test lib}
@@ -36,6 +36,18 @@ namespace(:test) do
           sh cmd
         end
       end
+    end
+
+    desc 'Use HTTP API to talk to supervisor'
+    task api: [:sup_start, :api_actual, :sup_shutdown]
+    task :api_actual do |t|
+      t.description = nil # Hide this task
+      t.libs.push 'lib'
+      t.test_files = FileList[
+        'test/integration/api/*_test.rb',
+      ]
+      t.verbose = true
+      t.warning = false
     end
 
     desc 'Use ssh cli transport to talk to supervisor'

--- a/Rakefile
+++ b/Rakefile
@@ -40,11 +40,11 @@ namespace(:test) do
 
     desc 'Use HTTP API to talk to supervisor'
     task api: [:sup_start, :api_actual, :sup_shutdown]
-    task :api_actual do |t|
+    Rake::TestTask.new(:api_actual) do |t|
       t.description = nil # Hide this task
       t.libs.push 'lib'
       t.test_files = FileList[
-        'test/integration/api/*_test.rb',
+        'test/integration/http-api/*_test.rb',
       ]
       t.verbose = true
       t.warning = false

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -78,6 +78,7 @@ module TrainPlugins
           unless prefix
             raise Train::TransportError, "All Habitat CLI connection options must begin with a recognized prefix (#{valid_cli_prefixes.join(', ')}) - saw #{option}"
           end
+
           options_by_prefix[prefix] ||= []
           options_by_prefix[prefix] << option
         end

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -72,10 +72,6 @@ module TrainPlugins
           unless prefix
             raise Train::TransportError, "All Habitat CLI connection options must begin with a recognized prefix (#{valid_cli_prefixes.join(', ')}) - saw #{option}"
           end
-<<<<<<< HEAD
-
-=======
->>>>>>> Add validation to CLI target options
           options_by_prefix[prefix] ||= []
           options_by_prefix[prefix] << option
         end

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -72,7 +72,10 @@ module TrainPlugins
           unless prefix
             raise Train::TransportError, "All Habitat CLI connection options must begin with a recognized prefix (#{valid_cli_prefixes.join(', ')}) - saw #{option}"
           end
+<<<<<<< HEAD
 
+=======
+>>>>>>> Add validation to CLI target options
           options_by_prefix[prefix] ||= []
           options_by_prefix[prefix] << option
         end

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -50,8 +50,14 @@ module TrainPlugins
 
       def habitat_api_client
         cached_client(:api_call, :HTTPGateway) do
-          # TODO: add authtoken
-          HTTPGateway.new(@options[:api_host])
+          # Send all options beginning with api_ to the HTTPGateway, stripping the prefix
+          api_options = {}
+          transport_options.each do |option_name, option_value|
+            next unless option_name.to_s.start_with? 'api_'
+
+            api_options[option_name.to_s.sub(/^api_/, '').to_sym] = option_value
+          end
+          HTTPGateway.new(api_options)
         end
       end
 

--- a/lib/train-habitat/httpgateway.rb
+++ b/lib/train-habitat/httpgateway.rb
@@ -22,9 +22,9 @@ module TrainPlugins
 
         resp = Response.new
         resp.raw_response = Net::HTTP.get_response(uri)
-        resp.code = resp.raw_response.code
+        resp.code = resp.raw_response.code.to_i
         if resp.code == 200
-          resp.body = JSON.parse(resp.raw_response.body)
+          resp.body = JSON.parse(resp.raw_response.body, symbolize_names: true)
         end
         resp
       end

--- a/lib/train-habitat/httpgateway.rb
+++ b/lib/train-habitat/httpgateway.rb
@@ -4,6 +4,8 @@ require 'net/http'
 module TrainPlugins
   module Habitat
     class HTTPGateway
+      Response = Struct.new(:code, :body, :raw_response)
+
       attr_reader :base_uri
 
       def initialize(opts)
@@ -12,6 +14,19 @@ module TrainPlugins
         if base_uri.port == 80 && opts[:url] !~ %r{\w+:\d+(\/|$)}
           base_uri.port = 9631
         end
+      end
+
+      def get_path(path)
+        uri = base_uri.dup
+        uri.path = path
+
+        resp = Response.new
+        resp.raw_response = Net::HTTP.get_response(uri)
+        resp.code = resp.raw_response.code
+        if resp.code == 200
+          resp.body = JSON.parse(resp.raw_response.body)
+        end
+        resp
       end
     end
   end

--- a/lib/train-habitat/httpgateway.rb
+++ b/lib/train-habitat/httpgateway.rb
@@ -1,41 +1,17 @@
-# frozen_string_literal: true
-
-require_relative 'illegal_state_error'
-
+require 'uri'
 require 'net/http'
-require 'json'
 
 module TrainPlugins
   module Habitat
     class HTTPGateway
-      attr_reader :uri
+      attr_reader :base_uri
 
-      def initialize(host)
-        @uri = URI("http://#{host}:9631/services")
-      end
-
-      def services
-        JSON.parse(Net::HTTP.get_response(uri).body)
-      end
-
-      def service(origin, name)
-        selected = services.select(&by_origin(origin))
-                           .select(&by_name(name))
-
-        selected.first
-      ensure
-        raise NoServicesFoundError.new(origin, name) if selected.empty?
-        raise MultipleServicesFoundError.new(origin, name) if selected.size > 1
-      end
-
-      private
-
-      def by_origin(origin)
-        ->(s) { s.dig('pkg', 'origin') == origin }
-      end
-
-      def by_name(name)
-        ->(s) { s.dig('pkg', 'name') == name }
+      def initialize(opts)
+        @base_uri = URI(opts[:url])
+        # check for provided port and default if not provided
+        if base_uri.port == 80 && opts[:url] !~ %r{\w+:\d+(\/|$)}
+          base_uri.port = 9631
+        end
       end
     end
   end

--- a/test/integration/http-api/service_list_test.rb
+++ b/test/integration/http-api/service_list_test.rb
@@ -1,0 +1,15 @@
+require_relative '../../helper'
+require 'train-habitat'
+
+describe 'Listing services via the HTTP Gateway API' do # rubocop:disable Metrics/BlockLength
+  let(:opts) { { api_url: 'http://127.0.0.1:9631' } } # From Vagrantfile
+  let(:conn) { Train.create(:habitat, opts).connection }
+  let(:hac) { conn.habitat_api_client }
+
+  it 'should be able to fetch /services' do
+    resp = hac.get_path('/services')
+    resp.code.must_equal 200
+    resp.body.count.must_equal 1
+    resp.body[0][:spec_identifier].must_equal 'core/httpd'
+  end
+end

--- a/test/integration/http-api/service_list_test.rb
+++ b/test/integration/http-api/service_list_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../helper'
 require 'train-habitat'
 
-describe 'Listing services via the HTTP Gateway API' do # rubocop:disable Metrics/BlockLength
+describe 'Listing services via the HTTP Gateway API' do
   let(:opts) { { api_url: 'http://127.0.0.1:9631' } } # From Vagrantfile
   let(:conn) { Train.create(:habitat, opts).connection }
   let(:hac) { conn.habitat_api_client }

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -44,18 +44,19 @@ describe TrainPlugins::Habitat::Connection do
   #                                 API Options
   # =========================================================================== #
   describe '#api_options_provided?' do
-    describe 'when api options are present' do
-      let(:opt) { { api_url: 'http://somewhere.com' } }
-      it 'should find the options' do
-        conn.api_options_provided?.must_equal true
-      end
-    end
     describe 'when api options are absent' do
       let(:opt) { { cli_test_host: 'somewhere.com' } }
       it 'should not find the options' do
         TrainPlugins::Habitat::Transport.expects(:cli_transport_prefixes).returns({ cli_test: :test }).at_least_once
         TrainPlugins::Habitat::Connection.any_instance.stubs(:initialize_cli_connection!)
         conn.api_options_provided?.must_equal false
+      end
+    end
+
+    describe 'when api options are present' do
+      let(:opt) { { api_url: 'http://somewhere.com:9631' } }
+      it 'should find the options' do
+        conn.api_options_provided?.must_equal true
       end
     end
   end
@@ -123,8 +124,15 @@ describe TrainPlugins::Habitat::Connection do
   # =========================================================================== #
 
   describe '#habitat_api_client' do
+    let(:opt) { { api_url: 'http://somewhere.com:9631' } }
+
     it 'should return kind of TrainPlugins::Habitat::HTTPGateway' do
       conn.habitat_api_client.must_be_kind_of TrainPlugins::Habitat::HTTPGateway
+    end
+
+    it 'should create a HTTPGateway with the right base URL' do
+      conn.habitat_api_client.wont_be_nil
+      conn.habitat_api_client.base_uri.to_s.must_equal opt[:api_url]
     end
 
     it 'returns a new instance when cache is disabled' do

--- a/test/unit/httpgateway_test.rb
+++ b/test/unit/httpgateway_test.rb
@@ -1,10 +1,10 @@
 require './test/helper'
 require './lib/train-habitat/httpgateway'
 
-describe TrainPlugins::Habitat::HTTPGateway do # rubocop: disable Metrics/BlockLength
+describe TrainPlugins::Habitat::HTTPGateway do
   let(:hgw) { TrainPlugins::Habitat::HTTPGateway.new(opts) }
   describe 'when a full URL is provided' do
-    let(:opts) { { url: 'http://habitat01.inspec.io:9631', } }
+    let(:opts) { { url: 'http://habitat01.inspec.io:9631' } }
 
     it 'should make the proper object' do
       hgw.must_be_kind_of TrainPlugins::Habitat::HTTPGateway
@@ -14,17 +14,40 @@ describe TrainPlugins::Habitat::HTTPGateway do # rubocop: disable Metrics/BlockL
       hgw.base_uri.must_be_kind_of URI
       hgw.base_uri.to_s.must_equal opts[:url]
     end
-
-    # it 'should accept paths'
-    # it 'should automatically unpack JSON responses'
   end
 
   describe 'when a URL without port is provided' do
-    let(:opts) { { url: 'http://habitat01.inspec.io', } }
+    let(:opts) { { url: 'http://habitat01.inspec.io' } }
 
     it 'assumes port 9631' do
       hgw.base_uri.port.must_equal 9631
     end
   end
-end
 
+  describe 'when fetching paths' do
+    let(:opts) { { url: 'http://habitat01.inspec.io:9631' } }
+    let(:service_response_mock) do
+      service_mock = mock
+      service_mock.expects(:code).returns(200)
+      service_mock.expects(:body).returns(File.read('test/unit/data/single_response.json')).at_least_once
+      service_mock
+    end
+
+    it 'should be able to get paths' do
+      Net::HTTP.stubs(:get_response).returns(service_response_mock)
+
+      response = hgw.get_path('/service') # No exception thrown
+      response.wont_be_nil
+      response.must_be_kind_of TrainPlugins::Habitat::HTTPGateway::Response
+      response.code.must_equal 200
+    end
+
+    it 'should automatically unpack JSON responses' do
+      Net::HTTP.stubs(:get_response).returns(service_response_mock)
+
+      response = hgw.get_path('/service') # No exception thrown
+      response.body.must_be_kind_of Array # Apparently they always send as an array
+      response.raw_response.body.must_be_kind_of String
+    end
+  end
+end

--- a/test/unit/httpgateway_test.rb
+++ b/test/unit/httpgateway_test.rb
@@ -46,7 +46,8 @@ describe TrainPlugins::Habitat::HTTPGateway do
       Net::HTTP.stubs(:get_response).returns(service_response_mock)
 
       response = hgw.get_path('/service') # No exception thrown
-      response.body.must_be_kind_of Array # Apparently they always send as an array
+      response.body.must_be_kind_of Array # Apparently they always send us an array
+      response.body[0].keys[0].must_be_kind_of Symbol # We symbolize the keys
       response.raw_response.body.must_be_kind_of String
     end
   end


### PR DESCRIPTION
This PR overhauls the prior work from 2018 regarding the way that the Train plugin handles the HTTP Gateway API.

 * Removes code related to parsing `/service` and `/services` endpoints, making the plugin agnostic about what paths are being requested and how to handle them. This allows the train plugin and resource pack to proceed at different cadences.

 * Reworks unit tests for above
 * Adds integration tests for above; you can now fetch `/services` from a supervisor running in a Vagrant setup.