### PR TITLE
Add API Bearer Token Authorization

### DIFF
--- a/lib/train-habitat/httpgateway.rb
+++ b/lib/train-habitat/httpgateway.rb
@@ -38,9 +38,7 @@ module TrainPlugins
       end
 
       # Private accessor
-      def auth_token
-        @auth_token
-      end
+      attr_reader :auth_token
     end
   end
 end

--- a/lib/train-habitat/transport.rb
+++ b/lib/train-habitat/transport.rb
@@ -14,7 +14,8 @@ module TrainPlugins
 
       # For service listings and health, specify supervisor api options.
       # https://www.habitat.sh/docs/using-habitat/#monitor-services-through-the-http-api
-      option :api_url, required: false, desc: 'The url at which a Habitat Supervisor exposes its API'
+      option :api_url, required: false, desc: 'The url at which a Habitat Supervisor exposes its HTTP Gateway API'
+      option :api_auth_token, required: false, desc: 'A bearer token which may be used to authenticate to the Supervisor HTTP Gateway'
 
       def self.cli_transport_prefixes
         {

--- a/test/integration/http-api/service_list_test.rb
+++ b/test/integration/http-api/service_list_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../helper'
 require 'train-habitat'
 
-describe 'Listing services via the HTTP Gateway API' do # rubocop:disable Metrics/BlockLength
+describe 'Listing services via the HTTP Gateway API' do
   let(:conn) { Train.create(:habitat, opts).connection }
   let(:hac) { conn.habitat_api_client }
 
@@ -14,7 +14,7 @@ describe 'Listing services via the HTTP Gateway API' do # rubocop:disable Metric
   end
 
   describe 'when the auth token is set' do
-    let(:opts)  do
+    let(:opts) do
       {
         api_url: 'http://127.0.0.1:9631', # From Vagrantfile
         api_auth_token: 'bulk-overripe-bananas-by-autogyro', # From bootstrap.sh

--- a/test/integration/http-api/service_list_test.rb
+++ b/test/integration/http-api/service_list_test.rb
@@ -1,15 +1,31 @@
 require_relative '../../helper'
 require 'train-habitat'
 
-describe 'Listing services via the HTTP Gateway API' do
-  let(:opts) { { api_url: 'http://127.0.0.1:9631' } } # From Vagrantfile
+describe 'Listing services via the HTTP Gateway API' do # rubocop:disable Metrics/BlockLength
   let(:conn) { Train.create(:habitat, opts).connection }
   let(:hac) { conn.habitat_api_client }
 
-  it 'should be able to fetch /services' do
-    resp = hac.get_path('/services')
-    resp.code.must_equal 200
-    resp.body.count.must_equal 1
-    resp.body[0][:spec_identifier].must_equal 'core/httpd'
+  describe 'when the auth token is not set' do
+    let(:opts) { { api_url: 'http://127.0.0.1:9631' } } # From Vagrantfile
+    it 'should fail to fetch /services' do
+      resp = hac.get_path('/services')
+      resp.code.must_equal 401
+    end
+  end
+
+  describe 'when the auth token is set' do
+    let(:opts)  do
+      {
+        api_url: 'http://127.0.0.1:9631', # From Vagrantfile
+        api_auth_token: 'bulk-overripe-bananas-by-autogyro', # From bootstrap.sh
+      }
+    end
+
+    it 'should be able to fetch /services' do
+      resp = hac.get_path('/services')
+      resp.code.must_equal 200
+      resp.body.count.must_equal 1
+      resp.body[0][:spec_identifier].must_equal 'core/httpd'
+    end
   end
 end

--- a/test/integration/shared/bootstrap.sh
+++ b/test/integration/shared/bootstrap.sh
@@ -27,6 +27,7 @@ if [ ! -f /etc/systemd/system/habitat.service ]; then
   After=network.target
 
   [Service]
+  Environment="HAB_SUP_GATEWAY_AUTH_TOKEN=bulk-overripe-bananas-by-autogyro"
   ExecStart=/bin/hab sup run
   Restart=always
   RestartSec=5

--- a/test/unit/httpgateway_test.rb
+++ b/test/unit/httpgateway_test.rb
@@ -1,7 +1,7 @@
 require './test/helper'
 require './lib/train-habitat/httpgateway'
 
-describe TrainPlugins::Habitat::HTTPGateway do
+describe TrainPlugins::Habitat::HTTPGateway do # rubocop:disable Metrics/BlockLength
   let(:hgw) { TrainPlugins::Habitat::HTTPGateway.new(opts) }
   describe 'when a full URL is provided' do
     let(:opts) { { url: 'http://habitat01.inspec.io:9631' } }
@@ -60,8 +60,8 @@ describe TrainPlugins::Habitat::HTTPGateway do
       end
       it 'should send it as an HTTP header' do
         HTTPClient.any_instance.expects(:get) \
-          .returns(service_response_mock) \
-          .with() { |_url, _query, headers| headers == {'Authorization' => 'Bearer some-secret'} }
+                  .returns(service_response_mock) \
+                  .with { |_url, _query, headers| headers == { 'Authorization' => 'Bearer some-secret' } }
 
         response = hgw.get_path('/service') # No exception thrown
         response.wont_be_nil


### PR DESCRIPTION
Closes #10 .

Switches the HTTP client library to be `httpclient` so we can set request headers, then implements bearer token authentication (per [docs](https://www.habitat.sh/docs/using-habitat/#authentication)).  Unit and integration tests are updated to cover the feature.