### PR TITLE
Pass through logger into sub-transport

### DIFF
--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -127,6 +127,9 @@ module TrainPlugins
 
         raise MultipleCliTransportsError, seen_cli_tranports.keys if seen_cli_transports.count > 1
 
+        # If no specific logger was passed in, re-use ours.
+        non_specific_options[:logger] = logger
+
         @cli_transport_name = seen_cli_transports.keys.first
         final_train_options = seen_cli_transports[cli_transport_name].merge(non_specific_options)
         @cli_transport = Train.create(cli_transport_name, final_train_options)

--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -1,0 +1,60 @@
+# Verify that loggers get passed around correctly.  This is
+# important, because the CLI transports can be very chatty.
+
+require './test/helper'
+require './lib/train-habitat/connection'
+require './lib/train-habitat/transport'
+require 'train/transports/ssh'
+
+describe 'logger facilities' do
+  let(:hab_xport) { Train.create(:habitat, opts) }
+  let(:hab_xport_logger) { hab_xport.instance_variable_get(:@logger) }
+  let(:hab_cxn) { hab_xport.connection }
+  let(:hab_cxn_logger) { hab_cxn.instance_variable_get(:@logger) }
+  let(:cli_xport) { hab_cxn.cli_transport }
+  let(:cli_xport_logger) { cli_xport.instance_variable_get(:@logger) }
+  let(:cli_cxn) { hab_cxn.cli_connection }
+  let(:cli_cxn_logger) { cli_cxn.instance_variable_get(:@logger) }
+
+  describe 'when not providing a logger' do
+    let(:opts) { {} }
+
+    describe 'when instantiating a transport' do
+      it 'should create a logger for you' do
+        hab_xport_logger.wont_be_nil
+        # The default logger allows logging of debug msgs
+        hab_xport_logger.debug?.must_equal true
+      end
+    end
+
+    describe 'when instantiating a connection' do
+      let(:opts) { { cli_ssh_host: '127.0.0.1' } }
+
+      it 'should create a logger for you' do
+        # Intercept platform detection
+        mock_cmd_out = mock
+        mock_cmd_out.expects(:stdout).returns('').at_least_once
+        mock_cmd_out.expects(:exit_status).returns(0).at_least_once
+        Train::Transports::SSH::Connection.any_instance.stubs(:run_command_via_connection).returns(mock_cmd_out)
+        Train::Extras::CommandWrapper.stubs(:load)
+
+        # a logger should be created for you in the hab connection
+        hab_cxn_logger.wont_be_nil
+        hab_cxn_logger.debug?.must_equal true
+
+        # one should be created in the cli transport
+        cli_xport_logger.wont_be_nil
+        cli_xport_logger.debug?.must_equal true
+
+        # one shuld be created in the cli cxn
+        cli_cxn_logger.wont_be_nil
+        cli_cxn_logger.debug?.must_equal true
+
+        # and they should all be the same one
+        the_logger = hab_cxn_logger
+        cli_xport_logger.must_be_same_as the_logger
+        cli_cxn_logger.must_be_same_as the_logger
+      end
+    end
+  end
+end


### PR DESCRIPTION
When created, a transport has a logger, which may be a special one passed in (eg from inspec).  If none is passed, Train makes a noisy one by default; this jams up JSON reports, for example.

So, if the main transport gets a logger, we must be sure to pass it on to any sub-transport, or the sub-transport will make a noisy logger of its own.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>