### PR TITLE
Add Connection#run_command

### DIFF
--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -44,6 +44,12 @@ module TrainPlugins
         cli_connection.run_command(hab_path + ' ' + command)
       end
 
+      # See #run_command in BaseConnection.
+      def run_command_via_connection(*args)
+        raise CliNotAvailableError(cli_tranport_names) unless cli_options_provided?
+        cli_connection.run_command(*args)
+      end
+
       def hab_path
         '/bin/hab'
       end

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -47,6 +47,7 @@ module TrainPlugins
       # See #run_command in BaseConnection.
       def run_command_via_connection(*args)
         raise CliNotAvailableError(cli_tranport_names) unless cli_options_provided?
+
         cli_connection.run_command(*args)
       end
 

--- a/test/integration/shared/bootstrap.sh
+++ b/test/integration/shared/bootstrap.sh
@@ -40,6 +40,8 @@ systemctl start habitat
 systemctl enable habitat
 fi
 
+hab license accept
+
 # Install a package
 pkg_origin=core
 pkg_name=httpd

--- a/test/integration/ssh/run_command_test.rb
+++ b/test/integration/ssh/run_command_test.rb
@@ -17,23 +17,34 @@ describe 'Using the SSH CLI transport' do
   end
   let(:hab_conn) { Train.create(:habitat, transport_opts).connection }
 
-  describe 'when using defaults' do
-    it 'should be able to get the hab version' do
-      result = hab_conn.run_hab_cli('--version')
-      result.exit_status.must_equal 0
-      # "hab 0.77.0/20190301212334\n"
-      result.stdout.must_match %r{^hab\s+\d+\.\d+\.\d+/\d+\n}
+  describe 'run_hab_cli' do
+    describe 'when using defaults' do
+      it 'should be able to get the hab version' do
+        result = hab_conn.run_hab_cli('--version')
+        result.exit_status.must_equal 0
+        # "hab 0.77.0/20190301212334\n"
+        result.stdout.must_match %r{^hab\s+\d+\.\d+\.\d+/\d+\n}
+      end
+    end
+
+    describe 'when using a setup that requires sudo' do
+      it 'should be able to get the hab version' do
+        result = hab_conn.run_hab_cli('svc status')
+        result.stderr.must_equal ''
+        result.exit_status.must_equal 0
+        # package                           type        desired  state  elapsed (s)  pid   group\n
+        # core/httpd/2.4.35/20190307151146  standalone  up       up     28521        1407  httpd.default\n
+        result.stdout.must_match(/^package\s+type\s+/)
+      end
     end
   end
 
-  describe 'when using a setup that requires sudo' do
-    it 'should be able to get the hab version' do
-      result = hab_conn.run_hab_cli('svc status')
+  describe 'run_command' do
+    it 'should be able to echo back' do
+      result = hab_conn.run_command('echo testresult')
       result.stderr.must_equal ''
       result.exit_status.must_equal 0
-      # package                           type        desired  state  elapsed (s)  pid   group\n
-      # core/httpd/2.4.35/20190307151146  standalone  up       up     28521        1407  httpd.default\n
-      result.stdout.must_match(/^package\s+type\s+/)
+      result.stdout.must_equal "testresult\n"
     end
   end
 end

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -111,13 +111,16 @@ describe TrainPlugins::Habitat::Connection do
   # =========================================================================== #
   #                         Running Hab CLI commands
   # =========================================================================== #
-  # TODO
-  # describe 'when cli non-transport options are passed' do
-  #   it 'should recognize them' do
-  #      # such as hab path
-  #      # such as env vars
-  #   end
-  # end
+
+  describe '#run_hab_cli' do
+    it 'should call the connection while prefixing with the hab path' do
+      cli_cxn = mock
+      cli_cxn.expects(:run_command).with('/bin/hab testcmd')
+      conn.expects(:cli_options_provided?).returns(true)
+      conn.expects(:cli_connection).returns(cli_cxn)
+      conn.run_hab_cli('testcmd')
+    end
+  end
 
   # =========================================================================== #
   #                                API Client

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -23,7 +23,6 @@ describe TrainPlugins::Habitat::Connection do
 
     %i(
       file_via_connection
-      run_command_via_connection
     ).each do |method_name|
       it "should NOT provide a #{method_name}() method" do
         # false passed to instance_methods says 'don't use inheritance'
@@ -113,12 +112,22 @@ describe TrainPlugins::Habitat::Connection do
   # =========================================================================== #
 
   describe '#run_hab_cli' do
-    it 'should call the connection while prefixing with the hab path' do
+    it 'should call the CLI connection while prefixing with the hab path' do
       cli_cxn = mock
       cli_cxn.expects(:run_command).with('/bin/hab testcmd')
       conn.expects(:cli_options_provided?).returns(true)
       conn.expects(:cli_connection).returns(cli_cxn)
       conn.run_hab_cli('testcmd')
+    end
+  end
+
+  describe '#run_command' do
+    it 'should call the CLI connection with the string provided' do
+      cli_cxn = mock
+      cli_cxn.expects(:run_command).with('testcmd')
+      conn.expects(:cli_options_provided?).returns(true)
+      conn.expects(:cli_connection).returns(cli_cxn)
+      conn.run_command('testcmd')
     end
   end
 


### PR DESCRIPTION
Closes #20

This PR adds support for calling the BaseConnection's `run_command` by implementing `run_command_via_connection`. This allows the user to run generic commands, not just `hab` subcommands.

As the train-habitat Connection might-have-a SSH Connection, we check for it first and then hand off the run_command call.

Unit and integration tests are included.

Also, this updates the integration test harness to accept the license for hab. 