### PR TITLE
Move train dependencies into Gemfile from gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "train-core", [">= 1.7.5", "< 4.0"]
+
 gemspec
 
 group :development do

--- a/train-habitat.gemspec
+++ b/train-habitat.gemspec
@@ -21,9 +21,6 @@ Gem::Specification.new do |spec|
   ).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
-  # All plugins should mention train, > 1.4
-  spec.add_dependency "train", ">= 1.7.5", "< 3.0"
-
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This moves the dependencies on train into the Gemfile; without this, all train plugins must agree on train constraints for the inspec package when we ship it.

Also increments the allowed upper version to `< 4`; v3 has no changes that break this plugin. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
