### PR TITLE
Don't ship the readme in the gem artifact

### DIFF
--- a/train-habitat.gemspec
+++ b/train-habitat.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license     = "Apache-2.0"
 
   spec.files = %w{
-    README.md train-habitat.gemspec Gemfile
+    train-habitat.gemspec Gemfile
   } + Dir.glob(
     "lib/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }


### PR DESCRIPTION
Shave a tiny bit of install size of the gem by not shipping the gem in
Workstation and other omnibus products

Signed-off-by: Tim Smith <tsmith@chef.io>