### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/train-habitat.rb
+++ b/lib/train-habitat.rb
@@ -3,7 +3,7 @@
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require "train-habitat/version"
-require "train-habitat/transport"
-require "train-habitat/platform"
-require "train-habitat/connection"
+require_relative "train-habitat/version"
+require_relative "train-habitat/transport"
+require_relative "train-habitat/platform"
+require_relative "train-habitat/connection"

--- a/lib/train-habitat/connection.rb
+++ b/lib/train-habitat/connection.rb
@@ -2,9 +2,9 @@
 
 require "net/http"
 require "json"
-require "train-habitat/httpgateway"
-require "train-habitat/platform"
-require "train-habitat/transport"
+require_relative "httpgateway"
+require_relative "platform"
+require_relative "transport"
 
 module TrainPlugins
   module Habitat

--- a/lib/train-habitat/transport.rb
+++ b/lib/train-habitat/transport.rb
@@ -1,6 +1,6 @@
 require "train"
 require "train/plugins"
-require "train-habitat/connection"
+require_relative "connection"
 
 module TrainPlugins
   module Habitat


### PR DESCRIPTION
require_relative is significantly faster and should be used when available. See @lamont-granquist for the full story.

Signed-off-by: Tim Smith <tsmith@chef.io>