### PR TITLE
Update Rake dep for a security issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "minitest", "~> 5.11"
   gem "mocha", "~> 1.8"
   gem "pry", "~> 0.11"
-  gem "rake", "~> 12.3"
+  gem "rake", ["~> 12.3", ">=12.3.3"]
   gem "rubocop", "~> 0.59"
   gem "chefstyle", "0.13.2"
 end


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
CVE-2020-8130 is a security issue in Rake 12.3.2 and previous. This updates the Gemfile dep to be 12.3.3 and later.
